### PR TITLE
Add new sentinel configuration options (announce-ip/announce-port)

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,17 @@ run with redis 2.8 or later.
 
 Configure logrotate rules for redis server. Default: true
 
+##### `announce_ip`
+
+Configure announce-ip in Sentinel configuration.  When announce-ip is provided, the Sentinel will claim the specified IP address
+in HELLO messages used to gossip its presence, instead of auto-detecting the local address as it usually does.
+
+##### `announce_port`
+
+Configure announce-port in Sentinel configuration.  Similarly when announce-port is provided and is valid and non-zero, Sentinel will announce the specified TCP port.
+
+*The above two configuration directives are useful in environments where, because of NAT, Sentinel is reachable from outside via a non-local address.  The two options don't need to be used together, if only announce-ip is provided, the Sentinel will announce the specified IP and the server port as specified by the "port" option. If only announce-port is provided, the Sentinel will announce the auto-detected local IP and the specified port.*
+
 ## Limitations
 
 This module is tested on CentOS 6.5 and Debian 7 (Wheezy) and should also run without problems on

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -47,6 +47,13 @@
 #   to this directory and than sentinel will start with this copy.
 # [*manage_logrotate*]
 #   Configure logrotate rules for redis sentinel. Default: true
+# [*announce_ip*]
+#   Configure announce-ip in Sentinel configuration.  When announce-ip is provided,
+#   the Sentinel will claim the specified IP address in HELLO messages used to gossip its presence,
+#   instead of auto-detecting the local address as it usually does.
+# [*announce_port*]
+#   Configure announce-port in Sentinel configuration.  Similarly when announce-port is provided,
+#   and is valid and non-zero, Sentinel will announce the specified TCP port.
 define redis::sentinel (
   $ensure           = 'present',
   $sentinel_name    = $name,
@@ -73,6 +80,8 @@ define redis::sentinel (
   $running          = true,
   $enabled          = true,
   $manage_logrotate = true,
+  $announce_ip      = undef,
+  $announce_port    = undef,
 ) {
   $sentinel_user              = $::redis::install::redis_user
   $sentinel_group             = $::redis::install::redis_group

--- a/templates/etc/sentinel.conf.erb
+++ b/templates/etc/sentinel.conf.erb
@@ -23,6 +23,14 @@ protected-mode <%= @protected_mode %>
 
 <% end -%>
 
+<% if @announce_ip then -%>
+sentinel announce-ip <%= @announce_ip %>
+<% end -%>
+
+<% if @announce_port then -%>
+sentinel announce-port <%= @announce_port %>
+<% end -%>
+
 <%
   #rules = scope.lookupvar('redis::sentinel::monitors')
   @monitors.sort.each do |name, rule| -%>


### PR DESCRIPTION
Adding configuration options for sentinel to define announce-ip, and
announce-port, including supporting documentation for usage.  Both new
options will default to undef, and will not affect the template unless
explicitly defined.